### PR TITLE
fix: error with currentExtent

### DIFF
--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -240,7 +240,9 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
                 headerBuilder: widget.headerBuilder,
                 minHeaderHeight: widget.minHeaderHeight,
                 maxHeaderHeight: widget.maxHeaderHeight,
-                currentExtent: _controller.size,
+                currentExtent: _controller.isAttached
+                    ? _controller.size
+                    : widget.initHeight,
                 scrollController: controller,
                 cacheExtent: _calculateCacheExtent(
                   MediaQuery.of(context).viewInsets.bottom,


### PR DESCRIPTION
---
name: error with currentExtent
about: Fixing a problem with currentExtent value of FlexibleBottomSheet content.
assignees: zaharovroman
---

<!--
    Thank you for contributing to our project!
    Provide a description of your changes below and a general summary in the title.
    Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - https://github.com/surfstudio/flutter-bottom-sheet/issues/57
- [ ] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Changes

currentExtent of FlexibleBottomSheet content has default value 

### What is the current behavior, and the steps to reproduce the issue?

- Press the "Open BottomSheet" button
- controller of _FlexibleBottomSheetState is not attached

### What is the expected behavior?

 The BottomSheet is shown and position value is 0.5

### How does this PR fix the problem?

size value of DraggableScrollableController is used only when controller is attached
