### PR TITLE
Fix: SafeArea in Ios does not work as expected

### DIFF
--- a/lib/src/flexible_bottom_sheet_route.dart
+++ b/lib/src/flexible_bottom_sheet_route.dart
@@ -300,7 +300,9 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
       bottomSheet = Theme(data: theme!, child: bottomSheet);
     }
 
-    return isSafeArea ? SafeArea(child: bottomSheet) : bottomSheet;
+    return isSafeArea
+        ? SafeArea(child: bottomSheet, bottom: false)
+        : bottomSheet;
   }
 
   @override


### PR DESCRIPTION
## Changes
The area color of the home indicator is transparent, I think it didn't work as expected.
<!--
For more info https://github.com/surfstudio/flutter-roadmap/blob/main/docs/PULL_REQUEST_TEMPLATE_README.md#changes
-->
## Checklist for self-check
- [ ] Commits and PRs have been filed according to [the rules on the project](https://github.com/surfstudio/surf-flutter-app-template#workflow-in-a-repository).
- [x] The author is marked as an assigne and assigned mandatory reviewers.
- [x] Required labels marked
- [ ] Specified related tasks and/or related PRs.
- [x] Specified Changes.
- [x] Attached videos/screenshots demonstrating the fix/feature.
- [x] All unspecified fields in the PR description deleted.
- [ ] New code covered by tests.

## Checklist for reviewers
- [ ] CI passed successfully _(with a green check mark)_.
- [x] PR is atomic, by volume no more than 400 (+-) corrected lines (not including codogen).

Design:
- [ ] System design corresponds to the agreements on structure and architecture on the project.
- [ ] The code is decomposed into necessary and sufficient components.

Functionality:
- [x] The code solves the problem.
- [x] Any changes to the user interface are reasonable and look good.

Complexity:
- [x] The code is clear, easy to read, functions are small, no more than 50 lines.
- [x] The logic is not overcomplicated, there is no overengineering (no code sections that may be needed in the future, but no one knows about it).

Tests:
- [ ] Updated or added tests for mandatory components.
- [ ] The tests are correct, helpful, and well designed/developed.

Naming:
- [ ] The naming of variables, methods, classes and other components is understandable.

Comments:
- [ ] The comments are understandable and helpful.

Documentation:
- [ ] All labels are correct
- [ ] Technical documentation updated (after approval, updates last reviewer). 

![screenshot](https://user-images.githubusercontent.com/108989782/197345642-3f29ed7d-f7f8-4600-8172-cc078d62ebc1.png)

