### PR TITLE
fix(): fix BottomSheet pop twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased, estimated N.N.N]
+### Added
+* Added generic param to FlexibleBottomSheet
 
 ## 3.1.2
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased, estimated N.N.N]
+## 4.0.0
 ### Fixed
 * BottomSheet pop twice
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased, estimated N.N.N]
+### Fixed
+* BottomSheet pop twice
 ### Added
 * Added generic param to FlexibleBottomSheet
 

--- a/example/lib/standard_bottom_sheet.dart
+++ b/example/lib/standard_bottom_sheet.dart
@@ -100,13 +100,13 @@ class _StandardExampleState extends State<StandardExample> {
                 child: Center(
                   child: Text(
                     'Header',
-                    style: Theme.of(context).textTheme.headline4,
+                    style: Theme.of(context).textTheme.headlineMedium,
                   ),
                 ),
               ),
               Text(
                 'position $offset',
-                style: Theme.of(context).textTheme.headline6,
+                style: Theme.of(context).textTheme.titleLarge,
               ),
             ],
           ),
@@ -140,7 +140,7 @@ class _BottomSheet extends StatelessWidget {
       children: [
         Text(
           'position $bottomSheetOffset',
-          style: Theme.of(context).textTheme.headline6,
+          style: Theme.of(context).textTheme.titleLarge,
         ),
         Column(
           children: _children,

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -44,8 +44,7 @@ typedef FlexibleDraggableScrollableHeaderWidgetBuilder = Widget Function(
 /// and [bottomSheetOffset] for determining the position of the BottomSheet
 /// relative to the upper border of the screen.
 /// [bottomSheetOffset] - fractional value of offset.
-typedef FlexibleDraggableScrollableWidgetBodyBuilder = SliverChildDelegate
-    Function(
+typedef FlexibleDraggableScrollableWidgetBodyBuilder = SliverChildDelegate Function(
   BuildContext context,
   double bottomSheetOffset,
 );
@@ -89,7 +88,7 @@ typedef FlexibleDraggableScrollableWidgetBodyBuilder = SliverChildDelegate
 /// [bottomSheetColor] - bottom sheet color. If you want to make rounded edges,
 /// pass a [Colors.transparent] here, and set the color and border radius of
 /// the bottom sheet in the [decoration].
-class FlexibleBottomSheet extends StatefulWidget {
+class FlexibleBottomSheet<T> extends StatefulWidget {
   final double minHeight;
   final double initHeight;
   final double maxHeight;
@@ -107,9 +106,11 @@ class FlexibleBottomSheet extends StatefulWidget {
   final VoidCallback? onDismiss;
   final Color? keyboardBarrierColor;
   final Color? bottomSheetColor;
+  final PopupRoute<T>? route;
 
   FlexibleBottomSheet({
     Key? key,
+    this.route,
     this.minHeight = 0,
     this.initHeight = 0.5,
     this.maxHeight = 1,
@@ -137,6 +138,7 @@ class FlexibleBottomSheet extends StatefulWidget {
         super(key: key);
 
   FlexibleBottomSheet.collapsible({
+    required PopupRoute<T> route,
     Key? key,
     double initHeight = 0.5,
     double maxHeight = 1,
@@ -153,6 +155,7 @@ class FlexibleBottomSheet extends StatefulWidget {
     Color? keyboardBarrierColor,
     Color? bottomSheetColor,
   }) : this(
+          route: route,
           key: key,
           maxHeight: maxHeight,
           draggableScrollableController: draggableScrollableController,
@@ -189,8 +192,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
   @override
   void initState() {
     super.initState();
-    _controller =
-        widget.draggableScrollableController ?? DraggableScrollableController();
+    _controller = widget.draggableScrollableController ?? DraggableScrollableController();
     _widgetBinding = WidgetsBinding.instance;
     widget.animationController?.addStatusListener(_animationStatusListener);
   }
@@ -248,15 +250,12 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
                 headerBuilder: widget.headerBuilder,
                 minHeaderHeight: widget.minHeaderHeight,
                 maxHeaderHeight: widget.maxHeaderHeight,
-                currentExtent: _controller.isAttached
-                    ? _controller.size
-                    : widget.initHeight,
+                currentExtent: _controller.isAttached ? _controller.size : widget.initHeight,
                 scrollController: controller,
                 cacheExtent: _calculateCacheExtent(
                   MediaQuery.of(context).viewInsets.bottom,
                 ),
-                getContentHeight:
-                    !widget.isExpand ? _changeInitAndMaxHeight : null,
+                getContentHeight: !widget.isExpand ? _changeInitAndMaxHeight : null,
               ),
             ),
           );
@@ -309,8 +308,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
       final widgetOffset = FocusManager.instance.primaryFocus!.offset.dy;
       final screenHeight = MediaQuery.of(context).size.height;
 
-      final targetWidgetOffset =
-          screenHeight - keyboardHeight - widgetHeight - 20;
+      final targetWidgetOffset = screenHeight - keyboardHeight - widgetHeight - 20;
       final valueToScroll = widgetOffset - targetWidgetOffset;
       final currentOffset = controller.offset;
       if (valueToScroll > 0) {
@@ -336,8 +334,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
   // Method that listens for changing AnimationStatus, to track the closing of
   // the bottom sheet by clicking above it.
   void _animationStatusListener(AnimationStatus status) {
-    if (status == AnimationStatus.reverse ||
-        status == AnimationStatus.dismissed) {
+    if (status == AnimationStatus.reverse || status == AnimationStatus.dismissed) {
       _isClosing = true;
     }
   }
@@ -346,6 +343,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
     if (widget.isCollapsible) {
       if (widget.onDismiss != null) widget.onDismiss!();
       Navigator.maybePop(context);
+      WidgetsBinding.instance.addPostFrameCallback((_) => widget.route?.changedInternalState());
     }
   }
 
@@ -415,8 +413,7 @@ class _ContentState extends State<_Content> {
     if (widget.getContentHeight != null) {
       WidgetsBinding.instance.addPostFrameCallback(
         (timeStamp) {
-          final renderContent =
-              _contentKey.currentContext!.findRenderObject() as RenderBox;
+          final renderContent = _contentKey.currentContext!.findRenderObject() as RenderBox;
           widget.getContentHeight!(renderContent.size.height);
         },
       );

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -44,8 +44,7 @@ typedef FlexibleDraggableScrollableHeaderWidgetBuilder = Widget Function(
 /// and [bottomSheetOffset] for determining the position of the BottomSheet
 /// relative to the upper border of the screen.
 /// [bottomSheetOffset] - fractional value of offset.
-typedef FlexibleDraggableScrollableWidgetBodyBuilder = SliverChildDelegate
-    Function(
+typedef FlexibleDraggableScrollableWidgetBodyBuilder = SliverChildDelegate Function(
   BuildContext context,
   double bottomSheetOffset,
 );
@@ -193,8 +192,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
   @override
   void initState() {
     super.initState();
-    _controller =
-        widget.draggableScrollableController ?? DraggableScrollableController();
+    _controller = widget.draggableScrollableController ?? DraggableScrollableController();
     _widgetBinding = WidgetsBinding.instance;
     widget.animationController?.addStatusListener(_animationStatusListener);
   }
@@ -244,7 +242,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
             child: Scaffold(
               backgroundColor: widget.bottomSheetColor ??
                   Theme.of(context).bottomSheetTheme.backgroundColor ??
-                  Theme.of(context).backgroundColor,
+                  Theme.of(context).colorScheme.background,
               body: _Content(
                 builder: widget.builder,
                 decoration: widget.decoration,
@@ -252,15 +250,12 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
                 headerBuilder: widget.headerBuilder,
                 minHeaderHeight: widget.minHeaderHeight,
                 maxHeaderHeight: widget.maxHeaderHeight,
-                currentExtent: _controller.isAttached
-                    ? _controller.size
-                    : widget.initHeight,
+                currentExtent: _controller.isAttached ? _controller.size : widget.initHeight,
                 scrollController: controller,
                 cacheExtent: _calculateCacheExtent(
                   MediaQuery.of(context).viewInsets.bottom,
                 ),
-                getContentHeight:
-                    !widget.isExpand ? _changeInitAndMaxHeight : null,
+                getContentHeight: !widget.isExpand ? _changeInitAndMaxHeight : null,
               ),
             ),
           );
@@ -313,8 +308,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
       final widgetOffset = FocusManager.instance.primaryFocus!.offset.dy;
       final screenHeight = MediaQuery.of(context).size.height;
 
-      final targetWidgetOffset =
-          screenHeight - keyboardHeight - widgetHeight - 20;
+      final targetWidgetOffset = screenHeight - keyboardHeight - widgetHeight - 20;
       final valueToScroll = widgetOffset - targetWidgetOffset;
       final currentOffset = controller.offset;
       if (valueToScroll > 0) {
@@ -340,8 +334,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
   // Method that listens for changing AnimationStatus, to track the closing of
   // the bottom sheet by clicking above it.
   void _animationStatusListener(AnimationStatus status) {
-    if (status == AnimationStatus.reverse ||
-        status == AnimationStatus.dismissed) {
+    if (status == AnimationStatus.reverse || status == AnimationStatus.dismissed) {
       _isClosing = true;
     }
   }
@@ -350,8 +343,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
     if (widget.isCollapsible) {
       if (widget.onDismiss != null) widget.onDismiss!();
       Navigator.maybePop(context);
-      WidgetsBinding.instance
-          .addPostFrameCallback((_) => widget.route?.changedInternalState());
+      WidgetsBinding.instance.addPostFrameCallback((_) => widget.route?.changedInternalState());
     }
   }
 
@@ -421,8 +413,7 @@ class _ContentState extends State<_Content> {
     if (widget.getContentHeight != null) {
       WidgetsBinding.instance.addPostFrameCallback(
         (timeStamp) {
-          final renderContent =
-              _contentKey.currentContext!.findRenderObject() as RenderBox;
+          final renderContent = _contentKey.currentContext!.findRenderObject() as RenderBox;
           widget.getContentHeight!(renderContent.size.height);
         },
       );

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -44,7 +44,8 @@ typedef FlexibleDraggableScrollableHeaderWidgetBuilder = Widget Function(
 /// and [bottomSheetOffset] for determining the position of the BottomSheet
 /// relative to the upper border of the screen.
 /// [bottomSheetOffset] - fractional value of offset.
-typedef FlexibleDraggableScrollableWidgetBodyBuilder = SliverChildDelegate Function(
+typedef FlexibleDraggableScrollableWidgetBodyBuilder = SliverChildDelegate
+    Function(
   BuildContext context,
   double bottomSheetOffset,
 );
@@ -192,7 +193,8 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
   @override
   void initState() {
     super.initState();
-    _controller = widget.draggableScrollableController ?? DraggableScrollableController();
+    _controller =
+        widget.draggableScrollableController ?? DraggableScrollableController();
     _widgetBinding = WidgetsBinding.instance;
     widget.animationController?.addStatusListener(_animationStatusListener);
   }
@@ -250,12 +252,15 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
                 headerBuilder: widget.headerBuilder,
                 minHeaderHeight: widget.minHeaderHeight,
                 maxHeaderHeight: widget.maxHeaderHeight,
-                currentExtent: _controller.isAttached ? _controller.size : widget.initHeight,
+                currentExtent: _controller.isAttached
+                    ? _controller.size
+                    : widget.initHeight,
                 scrollController: controller,
                 cacheExtent: _calculateCacheExtent(
                   MediaQuery.of(context).viewInsets.bottom,
                 ),
-                getContentHeight: !widget.isExpand ? _changeInitAndMaxHeight : null,
+                getContentHeight:
+                    !widget.isExpand ? _changeInitAndMaxHeight : null,
               ),
             ),
           );
@@ -308,7 +313,8 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
       final widgetOffset = FocusManager.instance.primaryFocus!.offset.dy;
       final screenHeight = MediaQuery.of(context).size.height;
 
-      final targetWidgetOffset = screenHeight - keyboardHeight - widgetHeight - 20;
+      final targetWidgetOffset =
+          screenHeight - keyboardHeight - widgetHeight - 20;
       final valueToScroll = widgetOffset - targetWidgetOffset;
       final currentOffset = controller.offset;
       if (valueToScroll > 0) {
@@ -334,7 +340,8 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
   // Method that listens for changing AnimationStatus, to track the closing of
   // the bottom sheet by clicking above it.
   void _animationStatusListener(AnimationStatus status) {
-    if (status == AnimationStatus.reverse || status == AnimationStatus.dismissed) {
+    if (status == AnimationStatus.reverse ||
+        status == AnimationStatus.dismissed) {
       _isClosing = true;
     }
   }
@@ -343,7 +350,8 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
     if (widget.isCollapsible) {
       if (widget.onDismiss != null) widget.onDismiss!();
       Navigator.maybePop(context);
-      WidgetsBinding.instance.addPostFrameCallback((_) => widget.route?.changedInternalState());
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => widget.route?.changedInternalState());
     }
   }
 
@@ -413,7 +421,8 @@ class _ContentState extends State<_Content> {
     if (widget.getContentHeight != null) {
       WidgetsBinding.instance.addPostFrameCallback(
         (timeStamp) {
-          final renderContent = _contentKey.currentContext!.findRenderObject() as RenderBox;
+          final renderContent =
+              _contentKey.currentContext!.findRenderObject() as RenderBox;
           widget.getContentHeight!(renderContent.size.height);
         },
       );

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -274,7 +274,8 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
     if (widget.isCollapsible) {
       if (widget.onDismiss != null) widget.onDismiss!();
       Navigator.maybePop(context);
-      WidgetsBinding.instance.addPostFrameCallback((_) => widget.route?.changedInternalState());
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => widget.route?.changedInternalState());
     }
   }
 

--- a/lib/src/flexible_bottom_sheet_route.dart
+++ b/lib/src/flexible_bottom_sheet_route.dart
@@ -262,6 +262,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
       removeTop: true,
       child: isCollapsible
           ? FlexibleBottomSheet.collapsible(
+              route: this,
               initHeight: initHeight,
               maxHeight: maxHeight,
               builder: builder,
@@ -278,6 +279,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
               bottomSheetColor: bottomSheetColor,
             )
           : FlexibleBottomSheet(
+              route: this,
               minHeight: minHeight,
               initHeight: initHeight,
               maxHeight: maxHeight,

--- a/test/bottom_sheet_test.dart
+++ b/test/bottom_sheet_test.dart
@@ -82,18 +82,16 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             makeTestableWidget(
-              FlexibleBottomSheet(),
+              FlexibleBottomSheet<void>(),
             ),
           );
 
-          expect(() => FlexibleBottomSheet, returnsNormally);
+          expect(() => FlexibleBottomSheet<void>, returnsNormally);
 
-          final flexibleScrollNotifier = find
-              .byType(NotificationListener<DraggableScrollableNotification>);
+          final flexibleScrollNotifier = find.byType(NotificationListener<DraggableScrollableNotification>);
           expect(flexibleScrollNotifier, findsOneWidget);
 
-          final draggableScrollableSheet =
-              find.byType(DraggableScrollableSheet);
+          final draggableScrollableSheet = find.byType(DraggableScrollableSheet);
           expect(draggableScrollableSheet, findsOneWidget);
         },
       );
@@ -104,11 +102,11 @@ void main() {
         unawaited(showBottomSheet());
 
         await tester.pumpAndSettle();
-        expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+        expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
 
-        await tester.tap(find.byType(FlexibleBottomSheet));
+        await tester.tap(find.byType(FlexibleBottomSheet<void>));
         await tester.pumpAndSettle();
-        expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+        expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
       });
 
       testWidgets(
@@ -121,15 +119,13 @@ void main() {
           ));
 
           await tester.pumpAndSettle();
-          expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+          expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
 
           await tester.tapAt(const Offset(20.0, 20.0));
           await tester.pumpAndSettle();
           expect(
-            find.byType(FlexibleBottomSheet),
-            defaultBoolTestVariant.currentValue!
-                ? findsNothing
-                : findsOneWidget,
+            find.byType(FlexibleBottomSheet<void>),
+            defaultBoolTestVariant.currentValue! ? findsNothing : findsOneWidget,
           );
         },
         variant: defaultBoolTestVariant,
@@ -145,11 +141,11 @@ void main() {
           ));
           await tester.pumpAndSettle();
 
-          expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+          expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
 
           await tester.drag(
             find.byType(
-              FlexibleBottomSheet,
+              FlexibleBottomSheet<void>,
               skipOffstage: false,
             ),
             const Offset(0.0, 300.0),
@@ -157,10 +153,8 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(
-            find.byType(FlexibleBottomSheet),
-            defaultBoolTestVariant.currentValue!
-                ? findsNothing
-                : findsOneWidget,
+            find.byType(FlexibleBottomSheet<void>),
+            defaultBoolTestVariant.currentValue! ? findsNothing : findsOneWidget,
           );
         },
         variant: defaultBoolTestVariant,
@@ -174,17 +168,17 @@ void main() {
           unawaited(showBottomSheet(isCollapsible: false));
           await tester.pumpAndSettle();
 
-          expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+          expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
 
           await tester.drag(
-            find.byType(FlexibleBottomSheet),
+            find.byType(FlexibleBottomSheet<void>),
             const Offset(0, -800),
           );
 
           await tester.pumpAndSettle();
 
           await tester.drag(
-            find.byType(FlexibleBottomSheet),
+            find.byType(FlexibleBottomSheet<void>),
             const Offset(0, -800),
           );
 
@@ -224,8 +218,7 @@ void main() {
             'Drag bottom sheet with anchors should have correct behaviour',
             (tester) async {
               final offset = _dragAnchorsVariants.currentValue!.offset;
-              final expectedResult =
-                  _dragAnchorsVariants.currentValue!.expectedResult;
+              final expectedResult = _dragAnchorsVariants.currentValue!.expectedResult;
 
               await tester.pumpWidget(app);
 
@@ -236,13 +229,13 @@ void main() {
 
               await tester.drag(
                 find.byType(
-                  FlexibleBottomSheet,
+                  FlexibleBottomSheet<void>,
                 ),
                 offset,
               );
               await tester.pumpAndSettle();
 
-              expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+              expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
 
               final fractionalHeight = getFractionalHeight(tester);
 
@@ -399,8 +392,7 @@ class _DragAnchorTestScenario {
   );
 }
 
-final ValueVariant<_DragAnchorTestScenario> _dragAnchorsVariants =
-    ValueVariant<_DragAnchorTestScenario>(
+final ValueVariant<_DragAnchorTestScenario> _dragAnchorsVariants = ValueVariant<_DragAnchorTestScenario>(
   {
     // When scrolling down 35, the bottom sheet should be 0.5.
     _DragAnchorTestScenario(const Offset(0, 35), 0.5),
@@ -452,8 +444,7 @@ class _AnchorsTestScenario {
   });
 }
 
-final ValueVariant<_AnchorsTestScenario> _anchorsTestVariants =
-    ValueVariant<_AnchorsTestScenario>(
+final ValueVariant<_AnchorsTestScenario> _anchorsTestVariants = ValueVariant<_AnchorsTestScenario>(
   {
     _AnchorsTestScenario(
       anchors: [0.2, 0.5, 1],

--- a/test/bottom_sheet_test.dart
+++ b/test/bottom_sheet_test.dart
@@ -88,10 +88,12 @@ void main() {
 
           expect(() => FlexibleBottomSheet<void>, returnsNormally);
 
-          final flexibleScrollNotifier = find.byType(NotificationListener<DraggableScrollableNotification>);
+          final flexibleScrollNotifier = find
+              .byType(NotificationListener<DraggableScrollableNotification>);
           expect(flexibleScrollNotifier, findsOneWidget);
 
-          final draggableScrollableSheet = find.byType(DraggableScrollableSheet);
+          final draggableScrollableSheet =
+              find.byType(DraggableScrollableSheet);
           expect(draggableScrollableSheet, findsOneWidget);
         },
       );
@@ -125,7 +127,9 @@ void main() {
           await tester.pumpAndSettle();
           expect(
             find.byType(FlexibleBottomSheet<void>),
-            defaultBoolTestVariant.currentValue! ? findsNothing : findsOneWidget,
+            defaultBoolTestVariant.currentValue!
+                ? findsNothing
+                : findsOneWidget,
           );
         },
         variant: defaultBoolTestVariant,
@@ -154,7 +158,9 @@ void main() {
 
           expect(
             find.byType(FlexibleBottomSheet<void>),
-            defaultBoolTestVariant.currentValue! ? findsNothing : findsOneWidget,
+            defaultBoolTestVariant.currentValue!
+                ? findsNothing
+                : findsOneWidget,
           );
         },
         variant: defaultBoolTestVariant,
@@ -218,7 +224,8 @@ void main() {
             'Drag bottom sheet with anchors should have correct behaviour',
             (tester) async {
               final offset = _dragAnchorsVariants.currentValue!.offset;
-              final expectedResult = _dragAnchorsVariants.currentValue!.expectedResult;
+              final expectedResult =
+                  _dragAnchorsVariants.currentValue!.expectedResult;
 
               await tester.pumpWidget(app);
 
@@ -392,7 +399,8 @@ class _DragAnchorTestScenario {
   );
 }
 
-final ValueVariant<_DragAnchorTestScenario> _dragAnchorsVariants = ValueVariant<_DragAnchorTestScenario>(
+final ValueVariant<_DragAnchorTestScenario> _dragAnchorsVariants =
+    ValueVariant<_DragAnchorTestScenario>(
   {
     // When scrolling down 35, the bottom sheet should be 0.5.
     _DragAnchorTestScenario(const Offset(0, 35), 0.5),
@@ -444,7 +452,8 @@ class _AnchorsTestScenario {
   });
 }
 
-final ValueVariant<_AnchorsTestScenario> _anchorsTestVariants = ValueVariant<_AnchorsTestScenario>(
+final ValueVariant<_AnchorsTestScenario> _anchorsTestVariants =
+    ValueVariant<_AnchorsTestScenario>(
   {
     _AnchorsTestScenario(
       anchors: [0.2, 0.5, 1],

--- a/test/not_expanded_bottom_sheet_test.dart
+++ b/test/not_expanded_bottom_sheet_test.dart
@@ -69,7 +69,7 @@ void main() {
           ));
           await tester.pumpAndSettle();
 
-          expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+          expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
 
           final fractionalHeight = getFractionalHeight(tester);
           expect(fractionalHeight == initHeight, true);
@@ -93,7 +93,7 @@ void main() {
           ));
           await tester.pumpAndSettle();
 
-          expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+          expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
 
           final fractionalHeight = getFractionalHeight(tester);
           expect(fractionalHeight < initHeight, true);
@@ -167,7 +167,7 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      expect(find.byType(FlexibleBottomSheet), findsOneWidget);
+      expect(find.byType(FlexibleBottomSheet<void>), findsOneWidget);
 
       final fractionalHeight = getFractionalHeight(tester);
       expect(fractionalHeight == initHeight, true);

--- a/test/sticky_bottom_sheet_test.dart
+++ b/test/sticky_bottom_sheet_test.dart
@@ -91,8 +91,10 @@ void main() {
         () async {
           unawaited(
             showStickyBottomSheet(
-              headerHeight: _headerHeightTestVariants.currentValue!.headerHeight,
-              maxHeaderHeight: _headerHeightTestVariants.currentValue!.maxHeaderHeight,
+              headerHeight:
+                  _headerHeightTestVariants.currentValue!.headerHeight,
+              maxHeaderHeight:
+                  _headerHeightTestVariants.currentValue!.maxHeaderHeight,
             ),
           );
 
@@ -193,7 +195,8 @@ class _HeaderHeightTestScenario {
   });
 }
 
-final ValueVariant<_HeaderHeightTestScenario> _headerHeightTestVariants = ValueVariant<_HeaderHeightTestScenario>({
+final ValueVariant<_HeaderHeightTestScenario> _headerHeightTestVariants =
+    ValueVariant<_HeaderHeightTestScenario>({
   _HeaderHeightTestScenario(headerHeight: 200.0, matcher: returnsNormally),
   _HeaderHeightTestScenario(maxHeaderHeight: 200.0, matcher: returnsNormally),
   _HeaderHeightTestScenario(

--- a/test/sticky_bottom_sheet_test.dart
+++ b/test/sticky_bottom_sheet_test.dart
@@ -72,7 +72,7 @@ void main() {
 
       await tester.drag(
         find.byType(
-          FlexibleBottomSheet,
+          FlexibleBottomSheet<void>,
           skipOffstage: false,
         ),
         const Offset(0, -800),
@@ -91,10 +91,8 @@ void main() {
         () async {
           unawaited(
             showStickyBottomSheet(
-              headerHeight:
-                  _headerHeightTestVariants.currentValue!.headerHeight,
-              maxHeaderHeight:
-                  _headerHeightTestVariants.currentValue!.maxHeaderHeight,
+              headerHeight: _headerHeightTestVariants.currentValue!.headerHeight,
+              maxHeaderHeight: _headerHeightTestVariants.currentValue!.maxHeaderHeight,
             ),
           );
 
@@ -195,8 +193,7 @@ class _HeaderHeightTestScenario {
   });
 }
 
-final ValueVariant<_HeaderHeightTestScenario> _headerHeightTestVariants =
-    ValueVariant<_HeaderHeightTestScenario>({
+final ValueVariant<_HeaderHeightTestScenario> _headerHeightTestVariants = ValueVariant<_HeaderHeightTestScenario>({
   _HeaderHeightTestScenario(headerHeight: 200.0, matcher: returnsNormally),
   _HeaderHeightTestScenario(maxHeaderHeight: 200.0, matcher: returnsNormally),
   _HeaderHeightTestScenario(


### PR DESCRIPTION
---
name: Bug fix
about: Fixing a problem with Flutter Bottom Sheet.
---

<!--
    Thank you for contributing to our project!
    Provide a description of your changes below and a general summary in the title.
    Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
  - https://github.com/surfstudio/flutter-bottom-sheet/issues/72
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Changes
- adding overlay control.
- fix tests
### What is the current behavior, and the steps to reproduce the issue?
Sliding the bottomSheet to the bottom, then tapping the background will pop twice
and we will not stay on the current screen, but go back to the previous.
### What is the expected behavior?
BottomSheet close and we stay on the current screen.
### How does this PR fix the problem?
send the route created by the BottomSheet to the BottomSheet widget. Next, when you scroll down to close, the overlay is forced to update in order to block clicks on it.