### PR TITLE
fix(): snackbar issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased, estimated N.N.N]
+## 3.2.0
 ### Added
 * Added a new parameter that controls the display of the snackbar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased, estimated N.N.N]
+### Added
+* Added a new parameter that controls the display of the snackbar
 
 ## 3.1.2
 ### Fixed

--- a/example/lib/standard_bottom_sheet.dart
+++ b/example/lib/standard_bottom_sheet.dart
@@ -100,13 +100,13 @@ class _StandardExampleState extends State<StandardExample> {
                 child: Center(
                   child: Text(
                     'Header',
-                    style: Theme.of(context).textTheme.headline4,
+                    style: Theme.of(context).textTheme.headlineMedium,
                   ),
                 ),
               ),
               Text(
                 'position $offset',
-                style: Theme.of(context).textTheme.headline6,
+                style: Theme.of(context).textTheme.titleLarge,
               ),
             ],
           ),
@@ -140,7 +140,7 @@ class _BottomSheet extends StatelessWidget {
       children: [
         Text(
           'position $bottomSheetOffset',
-          style: Theme.of(context).textTheme.headline6,
+          style: Theme.of(context).textTheme.titleLarge,
         ),
         Column(
           children: _children,

--- a/example/lib/standard_bottom_sheet_example.dart
+++ b/example/lib/standard_bottom_sheet_example.dart
@@ -28,7 +28,7 @@ class _StandardBottomSheetExampleState
         );
       },
       anchors: [0, 0.5, 1],
-      isRegisterScaffold: false,
+      useRootScaffold: false,
     );
   }
 

--- a/example/lib/standard_bottom_sheet_example.dart
+++ b/example/lib/standard_bottom_sheet_example.dart
@@ -28,6 +28,7 @@ class _StandardBottomSheetExampleState
         );
       },
       anchors: [0, 0.5, 1],
+      isRegisterScaffold: false,
     );
   }
 
@@ -96,7 +97,23 @@ class _StandardBottomSheetExampleState
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           ElevatedButton(
+            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text("I'm a snackbar"),
+              ),
+            ),
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('Show SnackBar'),
+          ),
+          const SizedBox(height: 20),
+          const Text(
+            'To see how to customize the display of the snackbar click on the red button, then the green or blue button. The isRegisterScaffold property is responsible for the behavior',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 40),
+          ElevatedButton(
             onPressed: _showSheet,
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
             child: const Text('Open BottomSheet'),
           ),
           const SizedBox(height: 20),

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -107,6 +107,7 @@ class FlexibleBottomSheet extends StatefulWidget {
   final VoidCallback? onDismiss;
   final Color? keyboardBarrierColor;
   final Color? bottomSheetColor;
+  final bool isRegisterScaffold;
 
   FlexibleBottomSheet({
     Key? key,
@@ -127,6 +128,7 @@ class FlexibleBottomSheet extends StatefulWidget {
     this.keyboardBarrierColor,
     this.bottomSheetColor,
     this.draggableScrollableController,
+    this.isRegisterScaffold = true,
   })  : assert(minHeight >= 0 && minHeight <= 1),
         assert(maxHeight > 0 && maxHeight <= 1),
         assert(maxHeight > minHeight),
@@ -152,6 +154,7 @@ class FlexibleBottomSheet extends StatefulWidget {
     Decoration? decoration,
     Color? keyboardBarrierColor,
     Color? bottomSheetColor,
+    bool isRegisterScaffold = true,
   }) : this(
           key: key,
           maxHeight: maxHeight,
@@ -170,6 +173,7 @@ class FlexibleBottomSheet extends StatefulWidget {
           decoration: decoration,
           keyboardBarrierColor: keyboardBarrierColor,
           bottomSheetColor: bottomSheetColor,
+          isRegisterScaffold: isRegisterScaffold,
         );
 
   @override
@@ -237,11 +241,12 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
                 );
               }
             },
-            child: Scaffold(
+            child: _RegisterScaffold(
+              isRegisterScaffold: widget.isRegisterScaffold,
               backgroundColor: widget.bottomSheetColor ??
                   Theme.of(context).bottomSheetTheme.backgroundColor ??
-                  Theme.of(context).backgroundColor,
-              body: _Content(
+                  Theme.of(context).colorScheme.background,
+              child: _Content(
                 builder: widget.builder,
                 decoration: widget.decoration,
                 bodyBuilder: widget.bodyBuilder,
@@ -372,6 +377,33 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
     } else {
       return defaultExtent;
     }
+  }
+}
+
+/// Register [Scaffold] for [FlexibleBottomSheet].
+class _RegisterScaffold extends StatelessWidget {
+  final bool isRegisterScaffold;
+  final Widget child;
+  final Color backgroundColor;
+
+  const _RegisterScaffold({
+    required this.isRegisterScaffold,
+    required this.child,
+    required this.backgroundColor,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return isRegisterScaffold
+        ? Scaffold(
+            backgroundColor: backgroundColor,
+            body: child,
+          )
+        : ColoredBox(
+            color: backgroundColor,
+            child: child,
+          );
   }
 }
 

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -107,7 +107,7 @@ class FlexibleBottomSheet extends StatefulWidget {
   final VoidCallback? onDismiss;
   final Color? keyboardBarrierColor;
   final Color? bottomSheetColor;
-  final bool isRegisterScaffold;
+  final bool useRootScaffold;
 
   FlexibleBottomSheet({
     Key? key,
@@ -128,7 +128,7 @@ class FlexibleBottomSheet extends StatefulWidget {
     this.keyboardBarrierColor,
     this.bottomSheetColor,
     this.draggableScrollableController,
-    this.isRegisterScaffold = true,
+    this.useRootScaffold = true,
   })  : assert(minHeight >= 0 && minHeight <= 1),
         assert(maxHeight > 0 && maxHeight <= 1),
         assert(maxHeight > minHeight),
@@ -154,7 +154,7 @@ class FlexibleBottomSheet extends StatefulWidget {
     Decoration? decoration,
     Color? keyboardBarrierColor,
     Color? bottomSheetColor,
-    bool isRegisterScaffold = true,
+    bool useRootScaffold = true,
   }) : this(
           key: key,
           maxHeight: maxHeight,
@@ -173,7 +173,7 @@ class FlexibleBottomSheet extends StatefulWidget {
           decoration: decoration,
           keyboardBarrierColor: keyboardBarrierColor,
           bottomSheetColor: bottomSheetColor,
-          isRegisterScaffold: isRegisterScaffold,
+          useRootScaffold: useRootScaffold,
         );
 
   @override
@@ -351,7 +351,7 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
               }
             },
             child: _RegisterScaffold(
-              isRegisterScaffold: widget.isRegisterScaffold,
+              useRootScaffold: widget.useRootScaffold,
               backgroundColor: widget.bottomSheetColor ??
                   Theme.of(context).bottomSheetTheme.backgroundColor ??
                   Theme.of(context).colorScheme.background,
@@ -382,12 +382,12 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
 
 /// Register [Scaffold] for [FlexibleBottomSheet].
 class _RegisterScaffold extends StatelessWidget {
-  final bool isRegisterScaffold;
+  final bool useRootScaffold;
   final Widget child;
   final Color backgroundColor;
 
   const _RegisterScaffold({
-    required this.isRegisterScaffold,
+    required this.useRootScaffold,
     required this.child,
     required this.backgroundColor,
     Key? key,
@@ -395,7 +395,7 @@ class _RegisterScaffold extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return isRegisterScaffold
+    return useRootScaffold
         ? Scaffold(
             backgroundColor: backgroundColor,
             body: child,

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -199,83 +199,6 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
     widget.animationController?.addStatusListener(_animationStatusListener);
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return NotificationListener<DraggableScrollableNotification>(
-      onNotification: _scrolling,
-      child: DraggableScrollableSheet(
-        maxChildSize: _currentMaxChildSize,
-        minChildSize: widget.minHeight,
-        initialChildSize: _initialChildSize,
-        snap: widget.anchors != null,
-        controller: _controller,
-        snapSizes: widget.anchors,
-        expand: widget.isExpand,
-        builder: (
-          context,
-          controller,
-        ) {
-          return ChangeInsetsDetector(
-            handler: (change) {
-              final inset = change.currentInset;
-              final delta = change.delta;
-
-              if (delta > 0 && !_isClosing) {
-                _animateToMaxHeight();
-                _widgetBinding.addPostFrameCallback(
-                  (_) {
-                    _animateToFocused(controller);
-                  },
-                );
-              }
-              // checking for openness of the keyboard before opening the sheet
-              if (delta == 0 && inset > 0) {
-                _widgetBinding.addPostFrameCallback(
-                  (_) {
-                    setState(
-                      () {
-                        _initialChildSize = widget.maxHeight;
-                      },
-                    );
-                  },
-                );
-              }
-            },
-            child: _RegisterScaffold(
-              isRegisterScaffold: widget.isRegisterScaffold,
-              backgroundColor: widget.bottomSheetColor ??
-                  Theme.of(context).bottomSheetTheme.backgroundColor ??
-                  Theme.of(context).colorScheme.background,
-              child: _Content(
-                builder: widget.builder,
-                decoration: widget.decoration,
-                bodyBuilder: widget.bodyBuilder,
-                headerBuilder: widget.headerBuilder,
-                minHeaderHeight: widget.minHeaderHeight,
-                maxHeaderHeight: widget.maxHeaderHeight,
-                currentExtent: _controller.isAttached
-                    ? _controller.size
-                    : widget.initHeight,
-                scrollController: controller,
-                cacheExtent: _calculateCacheExtent(
-                  MediaQuery.of(context).viewInsets.bottom,
-                ),
-                getContentHeight:
-                    !widget.isExpand ? _changeInitAndMaxHeight : null,
-              ),
-            ),
-          );
-        },
-      ),
-    );
-  }
-
-  @override
-  void dispose() {
-    widget.animationController?.removeStatusListener(_animationStatusListener);
-    super.dispose();
-  }
-
   // Method will be called when scrolling.
   bool _scrolling(DraggableScrollableNotification notification) {
     if (_isClosing) return false;
@@ -427,11 +350,12 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet> {
                 );
               }
             },
-            child: Scaffold(
+            child: _RegisterScaffold(
+              isRegisterScaffold: widget.isRegisterScaffold,
               backgroundColor: widget.bottomSheetColor ??
                   Theme.of(context).bottomSheetTheme.backgroundColor ??
                   Theme.of(context).colorScheme.background,
-              body: _Content(
+              child: _Content(
                 builder: widget.builder,
                 decoration: widget.decoration,
                 bodyBuilder: widget.bodyBuilder,

--- a/lib/src/flexible_bottom_sheet_route.dart
+++ b/lib/src/flexible_bottom_sheet_route.dart
@@ -42,7 +42,7 @@ const Duration _bottomSheetDuration = Duration(milliseconds: 500);
 /// [duration] - animation speed when opening bottom sheet.
 /// [isSafeArea] - should the bottom sheet provide a SafeArea, false by default.
 /// [decoration] - BottomSheet decoration.
-/// [isRegisterScaffold] - if true, add Scaffold widget on widget tree. Default true.
+/// [useRootScaffold] - if true, add Scaffold widget on widget tree. Default true.
 Future<T?> showFlexibleBottomSheet<T>({
   required BuildContext context,
   required FlexibleDraggableScrollableWidgetBuilder builder,
@@ -62,7 +62,7 @@ Future<T?> showFlexibleBottomSheet<T>({
   Duration? duration,
   bool isSafeArea = false,
   BoxDecoration? decoration,
-  bool isRegisterScaffold = true,
+  bool useRootScaffold = true,
 }) {
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
@@ -88,7 +88,7 @@ Future<T?> showFlexibleBottomSheet<T>({
       duration: duration,
       isSafeArea: isSafeArea,
       decoration: decoration,
-      isRegisterScaffold: isRegisterScaffold,
+      useRootScaffold: useRootScaffold,
     ),
   );
 }
@@ -122,7 +122,7 @@ Future<T?> showFlexibleBottomSheet<T>({
 /// [barrierColor] - barrier color, if you pass [barrierColor] - [isModal] must be true.
 /// [duration] - animation speed when opening bottom sheet.
 /// [isSafeArea] - should the bottom sheet provide a SafeArea, false by default.
-/// [isRegisterScaffold] - if true, add Scaffold widget on widget tree. Default true.
+/// [useRootScaffold] - if true, add Scaffold widget on widget tree. Default true.
 Future<T?> showStickyFlexibleBottomSheet<T>({
   required BuildContext context,
   required FlexibleDraggableScrollableHeaderWidgetBuilder headerBuilder,
@@ -146,7 +146,7 @@ Future<T?> showStickyFlexibleBottomSheet<T>({
   Color? barrierColor,
   Duration? duration,
   bool isSafeArea = false,
-  bool isRegisterScaffold = true,
+  bool useRootScaffold = true,
 }) {
   assert(maxHeaderHeight != null || headerHeight != null);
   assert(debugCheckHasMediaQuery(context));
@@ -176,7 +176,7 @@ Future<T?> showStickyFlexibleBottomSheet<T>({
       barrierBottomSheetColor: barrierColor,
       duration: duration,
       isSafeArea: isSafeArea,
-      isRegisterScaffold: isRegisterScaffold,
+      useRootScaffold: useRootScaffold,
     ),
   );
 }
@@ -204,7 +204,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
   final Color? barrierBottomSheetColor;
   final Duration? duration;
   final bool isSafeArea;
-  final bool isRegisterScaffold;
+  final bool useRootScaffold;
 
   @override
   final String? barrierLabel;
@@ -231,7 +231,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
     required this.isExpand,
     required this.isModal,
     required this.isSafeArea,
-    required this.isRegisterScaffold,
+    required this.useRootScaffold,
     this.draggableScrollableController,
     this.builder,
     this.headerBuilder,
@@ -285,7 +285,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
               decoration: decoration,
               keyboardBarrierColor: keyboardBarrierColor,
               bottomSheetColor: bottomSheetColor,
-              isRegisterScaffold: isRegisterScaffold,
+              useRootScaffold: useRootScaffold,
             )
           : FlexibleBottomSheet(
               minHeight: minHeight,
@@ -303,7 +303,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
               decoration: decoration,
               keyboardBarrierColor: keyboardBarrierColor,
               bottomSheetColor: bottomSheetColor,
-              isRegisterScaffold: isRegisterScaffold,
+              useRootScaffold: useRootScaffold,
             ),
     );
 

--- a/lib/src/flexible_bottom_sheet_route.dart
+++ b/lib/src/flexible_bottom_sheet_route.dart
@@ -41,6 +41,7 @@ const Duration _bottomSheetDuration = Duration(milliseconds: 500);
 /// [duration] - animation speed when opening bottom sheet.
 /// [isSafeArea] - should the bottom sheet provide a SafeArea, false by default.
 /// [decoration] - BottomSheet decoration.
+/// [isRegisterScaffold] - if true, add Scaffold widget on widget tree. Default true.
 Future<T?> showFlexibleBottomSheet<T>({
   required BuildContext context,
   required FlexibleDraggableScrollableWidgetBuilder builder,
@@ -60,6 +61,7 @@ Future<T?> showFlexibleBottomSheet<T>({
   Duration? duration,
   bool isSafeArea = false,
   BoxDecoration? decoration,
+  bool isRegisterScaffold = true,
 }) {
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
@@ -85,6 +87,7 @@ Future<T?> showFlexibleBottomSheet<T>({
       duration: duration,
       isSafeArea: isSafeArea,
       decoration: decoration,
+      isRegisterScaffold: isRegisterScaffold,
     ),
   );
 }
@@ -118,6 +121,7 @@ Future<T?> showFlexibleBottomSheet<T>({
 /// [barrierColor] - barrier color, if you pass [barrierColor] - [isModal] must be true.
 /// [duration] - animation speed when opening bottom sheet.
 /// [isSafeArea] - should the bottom sheet provide a SafeArea, false by default.
+/// [isRegisterScaffold] - if true, add Scaffold widget on widget tree. Default true.
 Future<T?> showStickyFlexibleBottomSheet<T>({
   required BuildContext context,
   required FlexibleDraggableScrollableHeaderWidgetBuilder headerBuilder,
@@ -141,6 +145,7 @@ Future<T?> showStickyFlexibleBottomSheet<T>({
   Color? barrierColor,
   Duration? duration,
   bool isSafeArea = false,
+  bool isRegisterScaffold = true,
 }) {
   assert(maxHeaderHeight != null || headerHeight != null);
   assert(debugCheckHasMediaQuery(context));
@@ -170,6 +175,7 @@ Future<T?> showStickyFlexibleBottomSheet<T>({
       barrierBottomSheetColor: barrierColor,
       duration: duration,
       isSafeArea: isSafeArea,
+      isRegisterScaffold: isRegisterScaffold,
     ),
   );
 }
@@ -197,6 +203,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
   final Color? barrierBottomSheetColor;
   final Duration? duration;
   final bool isSafeArea;
+  final bool isRegisterScaffold;
 
   @override
   final String? barrierLabel;
@@ -223,6 +230,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
     required this.isExpand,
     required this.isModal,
     required this.isSafeArea,
+    required this.isRegisterScaffold,
     this.draggableScrollableController,
     this.builder,
     this.headerBuilder,
@@ -276,6 +284,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
               decoration: decoration,
               keyboardBarrierColor: keyboardBarrierColor,
               bottomSheetColor: bottomSheetColor,
+              isRegisterScaffold: isRegisterScaffold,
             )
           : FlexibleBottomSheet(
               minHeight: minHeight,
@@ -293,6 +302,7 @@ class _FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
               decoration: decoration,
               keyboardBarrierColor: keyboardBarrierColor,
               bottomSheetColor: bottomSheetColor,
+              isRegisterScaffold: isRegisterScaffold,
             ),
     );
 

--- a/test/bottom_sheet_test.dart
+++ b/test/bottom_sheet_test.dart
@@ -52,10 +52,10 @@ void main() {
     bool? isModal,
     Color? barrierColor,
     List<double>? anchors,
-    bool? isRegisterScaffold,
+    bool? useRootScaffold,
   }) {
     return showFlexibleBottomSheet<void>(
-      isRegisterScaffold: isRegisterScaffold ?? true,
+      useRootScaffold: useRootScaffold ?? true,
       minHeight: minHeight ?? 0,
       initHeight: initHeight ?? 0.5,
       maxHeight: maxHeight ?? 0.8,
@@ -227,7 +227,7 @@ void main() {
 
           showSnackBar();
 
-          unawaited(showBottomSheet(isRegisterScaffold: false));
+          unawaited(showBottomSheet(useRootScaffold: false));
 
           await tester.pumpAndSettle();
 

--- a/test/bottom_sheet_test.dart
+++ b/test/bottom_sheet_test.dart
@@ -97,11 +97,12 @@ void main() {
 
           expect(() => FlexibleBottomSheet, returnsNormally);
 
-          final flexibleScrollNotifier =
-              find.byType(NotificationListener<DraggableScrollableNotification>);
+          final flexibleScrollNotifier = find
+              .byType(NotificationListener<DraggableScrollableNotification>);
           expect(flexibleScrollNotifier, findsOneWidget);
 
-          final draggableScrollableSheet = find.byType(DraggableScrollableSheet);
+          final draggableScrollableSheet =
+              find.byType(DraggableScrollableSheet);
           expect(draggableScrollableSheet, findsOneWidget);
         },
       );
@@ -135,7 +136,9 @@ void main() {
           await tester.pumpAndSettle();
           expect(
             find.byType(FlexibleBottomSheet),
-            defaultBoolTestVariant.currentValue! ? findsNothing : findsOneWidget,
+            defaultBoolTestVariant.currentValue!
+                ? findsNothing
+                : findsOneWidget,
           );
         },
         variant: defaultBoolTestVariant,
@@ -164,7 +167,9 @@ void main() {
 
           expect(
             find.byType(FlexibleBottomSheet),
-            defaultBoolTestVariant.currentValue! ? findsNothing : findsOneWidget,
+            defaultBoolTestVariant.currentValue!
+                ? findsNothing
+                : findsOneWidget,
           );
         },
         variant: defaultBoolTestVariant,
@@ -258,7 +263,8 @@ void main() {
             'Drag bottom sheet with anchors should have correct behaviour',
             (tester) async {
               final offset = _dragAnchorsVariants.currentValue!.offset;
-              final expectedResult = _dragAnchorsVariants.currentValue!.expectedResult;
+              final expectedResult =
+                  _dragAnchorsVariants.currentValue!.expectedResult;
 
               await tester.pumpWidget(app);
 
@@ -485,7 +491,8 @@ class _AnchorsTestScenario {
   });
 }
 
-final ValueVariant<_AnchorsTestScenario> _anchorsTestVariants = ValueVariant<_AnchorsTestScenario>(
+final ValueVariant<_AnchorsTestScenario> _anchorsTestVariants =
+    ValueVariant<_AnchorsTestScenario>(
   {
     _AnchorsTestScenario(
       anchors: [0.2, 0.5, 1],

--- a/test/bottom_sheet_test.dart
+++ b/test/bottom_sheet_test.dart
@@ -97,12 +97,11 @@ void main() {
 
           expect(() => FlexibleBottomSheet, returnsNormally);
 
-          final flexibleScrollNotifier = find
-              .byType(NotificationListener<DraggableScrollableNotification>);
+          final flexibleScrollNotifier =
+              find.byType(NotificationListener<DraggableScrollableNotification>);
           expect(flexibleScrollNotifier, findsOneWidget);
 
-          final draggableScrollableSheet =
-              find.byType(DraggableScrollableSheet);
+          final draggableScrollableSheet = find.byType(DraggableScrollableSheet);
           expect(draggableScrollableSheet, findsOneWidget);
         },
       );
@@ -136,9 +135,7 @@ void main() {
           await tester.pumpAndSettle();
           expect(
             find.byType(FlexibleBottomSheet),
-            defaultBoolTestVariant.currentValue!
-                ? findsNothing
-                : findsOneWidget,
+            defaultBoolTestVariant.currentValue! ? findsNothing : findsOneWidget,
           );
         },
         variant: defaultBoolTestVariant,
@@ -167,9 +164,7 @@ void main() {
 
           expect(
             find.byType(FlexibleBottomSheet),
-            defaultBoolTestVariant.currentValue!
-                ? findsNothing
-                : findsOneWidget,
+            defaultBoolTestVariant.currentValue! ? findsNothing : findsOneWidget,
           );
         },
         variant: defaultBoolTestVariant,
@@ -205,31 +200,35 @@ void main() {
         },
       );
 
-      testWidgets('Show SnackBar with Scaffold in BottomSheet tree',
-          (tester) async {
-        await tester.pumpWidget(app);
+      testWidgets(
+        'Show SnackBar with Scaffold in BottomSheet tree',
+        (tester) async {
+          await tester.pumpWidget(app);
 
-        showSnackBar();
+          showSnackBar();
 
-        unawaited(showBottomSheet());
+          unawaited(showBottomSheet());
 
-        await tester.pumpAndSettle();
+          await tester.pumpAndSettle();
 
-        expect(find.byType(SnackBar), findsNWidgets(2));
-      });
+          expect(find.byType(SnackBar), findsNWidgets(2));
+        },
+      );
 
-      testWidgets('Show SnackBar without Scaffold in BottomSheet tree',
-          (tester) async {
-        await tester.pumpWidget(app);
+      testWidgets(
+        'Show SnackBar without Scaffold in BottomSheet tree',
+        (tester) async {
+          await tester.pumpWidget(app);
 
-        showSnackBar();
+          showSnackBar();
 
-        unawaited(showBottomSheet(isRegisterScaffold: false));
+          unawaited(showBottomSheet(isRegisterScaffold: false));
 
-        await tester.pumpAndSettle();
+          await tester.pumpAndSettle();
 
-        expect(find.byType(SnackBar), findsOneWidget);
-      });
+          expect(find.byType(SnackBar), findsOneWidget);
+        },
+      );
 
       group(
         'Anchors',
@@ -259,8 +258,7 @@ void main() {
             'Drag bottom sheet with anchors should have correct behaviour',
             (tester) async {
               final offset = _dragAnchorsVariants.currentValue!.offset;
-              final expectedResult =
-                  _dragAnchorsVariants.currentValue!.expectedResult;
+              final expectedResult = _dragAnchorsVariants.currentValue!.expectedResult;
 
               await tester.pumpWidget(app);
 
@@ -487,8 +485,7 @@ class _AnchorsTestScenario {
   });
 }
 
-final ValueVariant<_AnchorsTestScenario> _anchorsTestVariants =
-    ValueVariant<_AnchorsTestScenario>(
+final ValueVariant<_AnchorsTestScenario> _anchorsTestVariants = ValueVariant<_AnchorsTestScenario>(
   {
     _AnchorsTestScenario(
       anchors: [0.2, 0.5, 1],

--- a/test/bottom_sheet_test.dart
+++ b/test/bottom_sheet_test.dart
@@ -35,6 +35,13 @@ void main() {
     ),
   );
 
+  void showSnackBar() {
+    ScaffoldMessenger.of(savedContext).showSnackBar(const SnackBar(
+      content: Text('SnackBar'),
+      duration: Duration(seconds: 5),
+    ));
+  }
+
   Future<void> showBottomSheet({
     bool? isCollapsible,
     bool? isDismissible,
@@ -45,8 +52,10 @@ void main() {
     bool? isModal,
     Color? barrierColor,
     List<double>? anchors,
+    bool? isRegisterScaffold,
   }) {
     return showFlexibleBottomSheet<void>(
+      isRegisterScaffold: isRegisterScaffold ?? true,
       minHeight: minHeight ?? 0,
       initHeight: initHeight ?? 0.5,
       maxHeight: maxHeight ?? 0.8,
@@ -195,6 +204,32 @@ void main() {
           expect(fractionalHeight, moreOrLessEquals(0.8));
         },
       );
+
+      testWidgets('Show SnackBar with Scaffold in BottomSheet tree',
+          (tester) async {
+        await tester.pumpWidget(app);
+
+        showSnackBar();
+
+        unawaited(showBottomSheet());
+
+        await tester.pumpAndSettle();
+
+        expect(find.byType(SnackBar), findsNWidgets(2));
+      });
+
+      testWidgets('Show SnackBar without Scaffold in BottomSheet tree',
+          (tester) async {
+        await tester.pumpWidget(app);
+
+        showSnackBar();
+
+        unawaited(showBottomSheet(isRegisterScaffold: false));
+
+        await tester.pumpAndSettle();
+
+        expect(find.byType(SnackBar), findsOneWidget);
+      });
 
       group(
         'Anchors',

--- a/test/sticky_bottom_sheet_test.dart
+++ b/test/sticky_bottom_sheet_test.dart
@@ -100,8 +100,10 @@ void main() {
         () async {
           unawaited(
             showStickyBottomSheet(
-              headerHeight: _headerHeightTestVariants.currentValue!.headerHeight,
-              maxHeaderHeight: _headerHeightTestVariants.currentValue!.maxHeaderHeight,
+              headerHeight:
+                  _headerHeightTestVariants.currentValue!.headerHeight,
+              maxHeaderHeight:
+                  _headerHeightTestVariants.currentValue!.maxHeaderHeight,
             ),
           );
 

--- a/test/sticky_bottom_sheet_test.dart
+++ b/test/sticky_bottom_sheet_test.dart
@@ -33,14 +33,23 @@ void main() {
     ),
   );
 
+  void showSnackBar() {
+    ScaffoldMessenger.of(savedContext).showSnackBar(const SnackBar(
+      content: Text('SnackBar'),
+      duration: Duration(seconds: 5),
+    ));
+  }
+
   Future<void> showStickyBottomSheet({
     double? headerHeight,
     double? maxHeaderHeight,
     double? minHeaderHeight,
     Color? barrierColor,
     bool? isModal,
+    bool? isRegisterScaffold,
   }) {
     return showStickyFlexibleBottomSheet(
+      isRegisterScaffold: isRegisterScaffold ?? true,
       isModal: isModal ?? true,
       barrierColor: barrierColor,
       context: savedContext,
@@ -152,6 +161,33 @@ void main() {
       );
     },
   );
+
+  testWidgets('Show SnackBar with Scaffold in BottomSheet tree',
+      (tester) async {
+    await tester.pumpWidget(app);
+
+    showSnackBar();
+
+    unawaited(showStickyBottomSheet(headerHeight: 200.0));
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SnackBar), findsNWidgets(2));
+  });
+
+  testWidgets('Show SnackBar without Scaffold in BottomSheet tree',
+      (tester) async {
+    await tester.pumpWidget(app);
+
+    showSnackBar();
+
+    unawaited(
+        showStickyBottomSheet(headerHeight: 200.0, isRegisterScaffold: false));
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SnackBar), findsOneWidget);
+  });
 }
 
 final _listWidgets = [

--- a/test/sticky_bottom_sheet_test.dart
+++ b/test/sticky_bottom_sheet_test.dart
@@ -46,10 +46,10 @@ void main() {
     double? minHeaderHeight,
     Color? barrierColor,
     bool? isModal,
-    bool? isRegisterScaffold,
+    bool? useRootScaffold,
   }) {
     return showStickyFlexibleBottomSheet(
-      isRegisterScaffold: isRegisterScaffold ?? true,
+      useRootScaffold: useRootScaffold ?? true,
       isModal: isModal ?? true,
       barrierColor: barrierColor,
       context: savedContext,
@@ -185,7 +185,7 @@ void main() {
       showSnackBar();
 
       unawaited(
-        showStickyBottomSheet(headerHeight: 200.0, isRegisterScaffold: false),
+        showStickyBottomSheet(headerHeight: 200.0, useRootScaffold: false),
       );
 
       await tester.pumpAndSettle();

--- a/test/sticky_bottom_sheet_test.dart
+++ b/test/sticky_bottom_sheet_test.dart
@@ -100,10 +100,8 @@ void main() {
         () async {
           unawaited(
             showStickyBottomSheet(
-              headerHeight:
-                  _headerHeightTestVariants.currentValue!.headerHeight,
-              maxHeaderHeight:
-                  _headerHeightTestVariants.currentValue!.maxHeaderHeight,
+              headerHeight: _headerHeightTestVariants.currentValue!.headerHeight,
+              maxHeaderHeight: _headerHeightTestVariants.currentValue!.maxHeaderHeight,
             ),
           );
 
@@ -162,32 +160,37 @@ void main() {
     },
   );
 
-  testWidgets('Show SnackBar with Scaffold in BottomSheet tree',
-      (tester) async {
-    await tester.pumpWidget(app);
+  testWidgets(
+    'Show SnackBar with Scaffold in BottomSheet tree',
+    (tester) async {
+      await tester.pumpWidget(app);
 
-    showSnackBar();
+      showSnackBar();
 
-    unawaited(showStickyBottomSheet(headerHeight: 200.0));
+      unawaited(showStickyBottomSheet(headerHeight: 200.0));
 
-    await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
 
-    expect(find.byType(SnackBar), findsNWidgets(2));
-  });
+      expect(find.byType(SnackBar), findsNWidgets(2));
+    },
+  );
 
-  testWidgets('Show SnackBar without Scaffold in BottomSheet tree',
-      (tester) async {
-    await tester.pumpWidget(app);
+  testWidgets(
+    'Show SnackBar without Scaffold in BottomSheet tree',
+    (tester) async {
+      await tester.pumpWidget(app);
 
-    showSnackBar();
+      showSnackBar();
 
-    unawaited(
-        showStickyBottomSheet(headerHeight: 200.0, isRegisterScaffold: false));
+      unawaited(
+        showStickyBottomSheet(headerHeight: 200.0, isRegisterScaffold: false),
+      );
 
-    await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
 
-    expect(find.byType(SnackBar), findsOneWidget);
-  });
+      expect(find.byType(SnackBar), findsOneWidget);
+    },
+  );
 }
 
 final _listWidgets = [


### PR DESCRIPTION
## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Is there an existing issue for this PR?
https://github.com/surfstudio/flutter-bottom-sheet/issues/69
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [x] Have the tests been updated to match the changes in the PR?
- [x] Have you run the tests locally to confirm they pass?

## Changes

### How does this PR fix the problem?
Since the snackbar is shown relative to the current active scaffold, it was necessary to remove the scaffold from the widget tree, leaving the possibility of displaying the snackbar on top of the bottom sheet.
A new parameter was added that allows you to remove the scaffold from the bootom sheet widget tree.

With Scaffold in widget tree.

https://user-images.githubusercontent.com/86564275/216302668-8ac7c46a-517c-498d-ae1a-8a7c1d101e88.mov

Without Scaffold in widget tree.

https://user-images.githubusercontent.com/86564275/216302705-5adec5d6-eefe-4733-9b32-22a140ecb8b5.mov

