### PR TITLE
fix: arbitrarily disposes of the passed controller

### DIFF
--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -320,7 +320,9 @@ class _FlexibleBottomSheetState<T> extends State<FlexibleBottomSheet<T>> {
   @override
   void dispose() {
     widget.animationController?.removeStatusListener(_animationStatusListener);
-    _controller.dispose();
+    if (widget.draggableScrollableController == null) {
+      _controller.dispose();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
Thank you for providing an excellent package.
An unexpected behavior occurred during use, and I am writing a PR because I would like to contribute to a better package.

## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_ (use keywords like `fix`, `close`, `resolve` etc. if necessary)
- [x] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Attached videos/screenshots demonstrating the fix/feature.
- [x] Have you run the tests locally to confirm they pass?

## Changes

Current: 
For `DraggableScrollableController`, it is implemented to dispose the controller unconditionally when disposing without distinguishing between the controller created in FlexibleBottomSheet and the controller passed as a parameter.

Change:
In the case of `DraggableScrollableController` passed as a parameter from the outside, change it not to be disposed so that it can be managed by itself from the outside.

### What is the current behavior, and the steps to reproduce the issue?

In general, in the case of a controller passed to a widget or function, create/dispose is carried out by the entity that passed it. (ex. TextEditingController passed to TextField, ScrollController passed to ScrollView.)
However, FlexibleBottomSheet internally disposes the DraggableScrollableController passed as a parameter from the outside.

This causes confusion and an exception occurs in the code below.


```dart
final controller = DraggableScrollableController();

await showFlexibleBottomSheet(
context: context,
...
draggableScrollableController: controller,
);

controller.dispose(); 

// exception: The "dispose()" method on ~ was called during the call to
```

### What is the expected behavior?

No exception occurs.

### How does this PR fix the problem?

DraggableScrollableController passed as a parameter from outside is not disposed in FlexibleBottomSheet.
With this change, the controller can manage itself externally, 
and no exception is thrown when closing the bottomsheet in the code above.
