### PR TITLE
Support for Slivers with Multiple Box Children

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Widget _buildBottomSheet(
 ![Demo](https://raw.githubusercontent.com/surfstudio/flutter-bottom-sheet/main/assets/open-sticky-bottom-sheet.gif)
 
 To show sticky BottomSheet, use:  
-**You have to return SliverChildListDelegate from builder !!!**
+**You have to return SliverMultiBoxAdaptorWidget from builder (SliverList, SliverGrid or SliverFixedExtentList) !!!**
 
 ```dart
 showStickyFlexibleBottomSheet(
@@ -121,10 +121,17 @@ showStickyFlexibleBottomSheet(
     );
   },
   builder: (BuildContext context, double offset) {
-    return SliverChildListDelegate(
-      <Widget>[...],
+     return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        childCount: 5,
+        (BuildContext context, int index) {
+          return <Widget>....;
+        },
+      ),
     );
   },
+
+ 
   anchors: [0, 0.5, 1],
 );
 ```
@@ -146,7 +153,7 @@ All notable changes to this project will be documented in [this file](./CHANGELO
 
 ## Issues
 
-To report your issues,  submit them directly in the [Issues](https://github.com/surfstudio/flutter-bottom-sheet/issues) section.
+To report your issues, submit them directly in the [Issues](https://github.com/surfstudio/flutter-bottom-sheet/issues) section.
 
 ## Contribute
 

--- a/example/lib/standard_bottom_sheet_example.dart
+++ b/example/lib/standard_bottom_sheet_example.dart
@@ -97,8 +97,10 @@ class _StandardBottomSheetExampleState
         );
       },
       bodyBuilder: (context, offset) {
-        return SliverChildListDelegate(
-          _children,
+        return SliverList(
+          delegate: SliverChildListDelegate(
+            _children,
+          ),
         );
       },
       anchors: [0.2, 0.5, 0.8],

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -46,8 +46,8 @@ typedef FlexibleDraggableScrollableHeaderWidgetBuilder = Widget Function(
 /// and [bottomSheetOffset] for determining the position of the BottomSheet
 /// relative to the upper border of the screen.
 /// [bottomSheetOffset] - fractional value of offset.
-typedef FlexibleDraggableScrollableWidgetBodyBuilder = SliverChildDelegate
-    Function(
+typedef FlexibleDraggableScrollableWidgetBodyBuilder
+    = SliverMultiBoxAdaptorWidget Function(
   BuildContext context,
   double bottomSheetOffset,
 );
@@ -547,11 +547,9 @@ class _ContentState extends State<_Content> {
                 ),
               ),
             if (widget.bodyBuilder != null)
-              SliverList(
-                delegate: widget.bodyBuilder!(
-                  context,
-                  widget.currentExtent,
-                ),
+              widget.bodyBuilder!(
+                context,
+                widget.currentExtent,
               ),
           ],
         ),

--- a/lib/src/flexible_bottom_sheet.dart
+++ b/lib/src/flexible_bottom_sheet.dart
@@ -98,6 +98,7 @@ class FlexibleBottomSheet<T> extends StatefulWidget {
   final FlexibleDraggableScrollableWidgetBuilder? builder;
   final FlexibleDraggableScrollableHeaderWidgetBuilder? headerBuilder;
   final FlexibleDraggableScrollableWidgetBodyBuilder? bodyBuilder;
+  final EdgeInsets? bodyPadding;
   final bool isCollapsible;
   final bool isExpand;
   final DraggableScrollableController? draggableScrollableController;
@@ -122,6 +123,7 @@ class FlexibleBottomSheet<T> extends StatefulWidget {
     this.builder,
     this.headerBuilder,
     this.bodyBuilder,
+    this.bodyPadding,
     this.isCollapsible = false,
     this.isExpand = true,
     this.animationController,
@@ -152,6 +154,7 @@ class FlexibleBottomSheet<T> extends StatefulWidget {
     FlexibleDraggableScrollableWidgetBuilder? builder,
     FlexibleDraggableScrollableHeaderWidgetBuilder? headerBuilder,
     FlexibleDraggableScrollableWidgetBodyBuilder? bodyBuilder,
+    EdgeInsets? bodyPadding,
     bool isExpand = true,
     AnimationController? animationController,
     List<double>? anchors,
@@ -170,6 +173,7 @@ class FlexibleBottomSheet<T> extends StatefulWidget {
           builder: builder,
           headerBuilder: headerBuilder,
           bodyBuilder: bodyBuilder,
+          bodyPadding: bodyPadding,
           minHeight: 0,
           initHeight: initHeight,
           isCollapsible: true,
@@ -395,6 +399,7 @@ class _FlexibleBottomSheetState<T> extends State<FlexibleBottomSheet<T>> {
                   builder: widget.builder,
                   decoration: contentDecoration,
                   bodyBuilder: widget.bodyBuilder,
+                  bodyPadding: widget.bodyPadding,
                   headerBuilder: widget.headerBuilder,
                   minHeaderHeight: widget.minHeaderHeight,
                   maxHeaderHeight: widget.maxHeaderHeight,
@@ -468,6 +473,7 @@ class _Content extends StatefulWidget {
   final Decoration? decoration;
   final FlexibleDraggableScrollableHeaderWidgetBuilder? headerBuilder;
   final FlexibleDraggableScrollableWidgetBodyBuilder? bodyBuilder;
+  final EdgeInsets? bodyPadding;
   final double? minHeaderHeight;
   final double? maxHeaderHeight;
   final double currentExtent;
@@ -483,6 +489,7 @@ class _Content extends StatefulWidget {
     this.decoration,
     this.headerBuilder,
     this.bodyBuilder,
+    this.bodyPadding,
     this.minHeaderHeight,
     this.maxHeaderHeight,
     this.getContentHeight,
@@ -528,6 +535,9 @@ class _ContentState extends State<_Content> {
       );
     }
 
+    final bodyBuilder = widget.bodyBuilder;
+    final bodyPadding = widget.bodyPadding;
+
     return Material(
       type: MaterialType.transparency,
       child: DecoratedBox(
@@ -546,11 +556,19 @@ class _ContentState extends State<_Content> {
                   child: widget.headerBuilder!(context, widget.currentExtent),
                 ),
               ),
-            if (widget.bodyBuilder != null)
-              widget.bodyBuilder!(
-                context,
-                widget.currentExtent,
-              ),
+            if (bodyBuilder != null)
+              bodyPadding != null
+                  ? SliverPadding(
+                      padding: bodyPadding,
+                      sliver: bodyBuilder(
+                        context,
+                        widget.currentExtent,
+                      ),
+                    )
+                  : bodyBuilder(
+                      context,
+                      widget.currentExtent,
+                    ),
           ],
         ),
       ),

--- a/lib/src/flexible_bottom_sheet_route.dart
+++ b/lib/src/flexible_bottom_sheet_route.dart
@@ -101,6 +101,7 @@ Future<T?> showFlexibleBottomSheet<T>({
 /// even without a list.
 ///
 /// [bodyBuilder] - content's builder.
+/// [bodyPadding] padding for content's builder.
 /// [draggableScrollableController] that allow programmatically control bottom sheet.
 /// [minHeight] - min height in fractional value for bottom sheet. e.g. 0.1.
 /// [initHeight] - init height in fractional value for bottom sheet. e.g. 0.5.
@@ -132,6 +133,7 @@ Future<T?> showStickyFlexibleBottomSheet<T>({
   required BuildContext context,
   required FlexibleDraggableScrollableHeaderWidgetBuilder headerBuilder,
   required FlexibleDraggableScrollableWidgetBodyBuilder bodyBuilder,
+  EdgeInsets? bodyPadding,
   DraggableScrollableController? draggableScrollableController,
   double? minHeight,
   double? initHeight,
@@ -171,6 +173,7 @@ Future<T?> showStickyFlexibleBottomSheet<T>({
       draggableScrollableController: draggableScrollableController,
       isExpand: isExpand,
       bodyBuilder: bodyBuilder,
+      bodyPadding: bodyPadding,
       headerBuilder: headerBuilder,
       isModal: isModal,
       anchors: anchors,
@@ -193,6 +196,7 @@ class FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
   final FlexibleDraggableScrollableWidgetBuilder? builder;
   final FlexibleDraggableScrollableHeaderWidgetBuilder? headerBuilder;
   final FlexibleDraggableScrollableWidgetBodyBuilder? bodyBuilder;
+  final EdgeInsets? bodyPadding;
   final DraggableScrollableController? draggableScrollableController;
   final double minHeight;
   final double initHeight;
@@ -244,6 +248,7 @@ class FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
     this.builder,
     this.headerBuilder,
     this.bodyBuilder,
+    this.bodyPadding,
     this.theme,
     this.barrierLabel,
     this.anchors,
@@ -287,6 +292,7 @@ class FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
               builder: builder,
               headerBuilder: headerBuilder,
               bodyBuilder: bodyBuilder,
+              bodyPadding: bodyPadding,
               isExpand: isExpand,
               animationController: _animationController,
               anchors: anchors,
@@ -307,6 +313,7 @@ class FlexibleBottomSheetRoute<T> extends PopupRoute<T> {
               builder: builder,
               headerBuilder: headerBuilder,
               bodyBuilder: bodyBuilder,
+              bodyPadding: bodyPadding,
               isExpand: isExpand,
               animationController: _animationController,
               draggableScrollableController: draggableScrollableController,

--- a/test/sticky_bottom_sheet_test.dart
+++ b/test/sticky_bottom_sheet_test.dart
@@ -62,8 +62,10 @@ void main() {
         );
       },
       bodyBuilder: (context, offset) {
-        return SliverChildListDelegate(
-          _listWidgets,
+        return SliverList(
+          delegate: SliverChildListDelegate(
+            _listWidgets,
+          ),
         );
       },
     );


### PR DESCRIPTION
## Checklist

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Is there an existing issue for this PR?
  - _link issue here_ (use keywords like `fix`, `close`, `resolve` etc. if necessary)
- [x] Have the files been linted and formatted?
- [x] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [x] Attached videos/screenshots demonstrating the fix/feature.
- [x] Have you run the tests locally to confirm they pass?

## New Features
Adding the ability to use slivers that support or have multiple children instead of a list of children, such as SliverGrid, SliverList, SliverFixedExtentList.

### What new capabilities does this PR add?
1. Changing the return value of FlexibleDraggableScrollableWidgetBodyBuilder from SliverChildDelegate to SliverMultiBoxAdaptorWidget
2. Adding EdgeInsets? bodyPadding for adjusting the outer padding of the bodyBuilder.
    ```
    /// [bodyPadding] padding for content's builder.
    ```
    
Code example:
```
bodyPadding: const EdgeInsets.all(30),
bodyBuilder: (_, offset) {
  return SliverGrid(
    delegate: SliverChildBuilderDelegate(
      childCount: 10,
      (context, index) {
        return Container(color: Colors.blue);
      },
    ),
    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
      crossAxisCount: 2,
      mainAxisSpacing: 10,
      crossAxisSpacing: 10,
      childAspectRatio: 1,
    ),
  );
},
``` 

Media examples:
<video src="https://github.com/user-attachments/assets/df14e638-0282-42f1-964a-293ae34122db" width="240" height="320" controls></video>
<video src="https://github.com/user-attachments/assets/d5b450b2-c934-4cb2-9700-91c8ac360bfe" width="240" height="320" controls></video>

### What docs changes are needed to explain this?
I added comments for bodyPadding.
Updated readme.md and example for "Sticky BottomSheet"


Thank you for your attention!